### PR TITLE
Align emit_to signature to tauri

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -162,16 +162,16 @@ pub trait Event: NamedType {
     }
 
     /// Emits an event to all [targets](EventTarget) matching the given target.
-    fn emit_to<R: Runtime, H: Emitter<R> + Manager<R>>(
+    fn emit_to<R: Runtime, H: Emitter<R> + Manager<R>, I: Into<EventTarget>>(
         &self,
         handle: &H,
-        label: &str,
+        target: I,
     ) -> tauri::Result<()>
     where
         Self: Serialize + Clone,
     {
         handle.emit_to(
-            label,
+            target,
             &EventRegistry::get_event_name::<Self, _>(handle, Self::NAME),
             self,
         )

--- a/src/event.rs
+++ b/src/event.rs
@@ -150,7 +150,7 @@ pub trait Event: NamedType {
         )
     }
 
-    /// Emits an event to all [targets](EventTarget) matching the given target.
+    /// Emits an event to all [targets](EventTarget).
     fn emit<R: Runtime, H: Emitter<R> + Manager<R>>(&self, handle: &H) -> tauri::Result<()>
     where
         Self: Serialize + Clone,


### PR DESCRIPTION
Hi,

In this change I aligned the signature of emit_to with the one used in tauri. Also I fixed one comment ... :D

Check [tauri docs](https://docs.rs/tauri/latest/tauri/trait.Emitter.html#tymethod.emit_to) for comparison. 