### PR TITLE
return proxy in js __makeEvents__

### DIFF
--- a/src/lang/globals.js
+++ b/src/lang/globals.js
@@ -42,7 +42,7 @@ function __makeEvents__(mappings) {
 			get: (_, event) => {
 				const name = mappings[event];
 
-				new Proxy(() => {}, {
+				return new Proxy(() => {}, {
 					apply: (_, __, [window]) => ({
 						listen: (arg) => window.listen(name, arg),
 						once: (arg) => window.once(name, arg),


### PR DESCRIPTION
Hello! 

This is a small inconsistency between event handling on JS vs TS that results in `TypeError: undefined is not an object (evaluating 'events.myEvent.listen')` on JS.

Compare with the typescript version:
https://github.com/specta-rs/tauri-specta/blob/5cd56fe8a8d681ba5b649dc7fd4e2e2b001e4e57/src/lang/globals.ts#L34-L37