### PR TITLE
Classes

### DIFF
--- a/examples/app/src-tauri/src/bruh.rs
+++ b/examples/app/src-tauri/src/bruh.rs
@@ -1,0 +1,28 @@
+// TODO: Fix the issue causing this to be broken out
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+#[derive(Debug, Serialize, Deserialize, Type)]
+pub struct MyClass {
+    id: i32,
+}
+
+#[tauri_specta::class]
+impl MyClass {
+    pub fn method1(self, some_arg: String) {
+        println!("METHOD1: {:?} {}", self, some_arg);
+    }
+
+    pub fn method2(some_arg: String) {
+        println!("METHOD2: {}", some_arg);
+    }
+
+    // TODO: Support these
+    // pub fn method3(&mut self, some_arg: String) {
+    //     println!("METHOD3: {:?} {}", self, some_arg);
+    // }
+    // pub fn method4(&self, some_arg: String) {
+    //     println!("METHOD4: {:?} {}", self, some_arg);
+    // }
+}

--- a/examples/app/src-tauri/src/main.rs
+++ b/examples/app/src-tauri/src/main.rs
@@ -9,6 +9,8 @@ use specta_typescript::Typescript;
 use tauri_specta::*;
 use thiserror::Error;
 
+mod bruh;
+
 /// HELLO
 /// WORLD
 /// !!!!
@@ -126,8 +128,10 @@ fn main() {
             deprecated,
             typesafe_errors_using_thiserror,
             typesafe_errors_using_thiserror_with_value,
+            bruh::__MyClass__method1,
         ])
         .events(tauri_specta::collect_events![crate::DemoEvent, EmptyEvent])
+        .class::<bruh::MyClass>()
         .typ::<Custom>()
         .constant("universalConstant", 42);
 

--- a/examples/app/src/bindings-jsdoc.js
+++ b/examples/app/src/bindings-jsdoc.js
@@ -71,10 +71,22 @@ async typesafeErrorsUsingThiserrorWithValue()  {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  };
 }
+},
+/**
+ * @param { MyClass } 東京
+ * @param { string } someArg
+ * @returns { Promise<void> }
+ */
+async myClassMethod1(東京, someArg)  {
+    await TAURI_INVOKE("__MyClass__method1", { 東京, someArg });
 }
     }
 
 /** user-defined events **/
+
+
+
+/** user-defined classes **/
 
 
     /**
@@ -168,7 +180,7 @@ function __makeEvents__(mappings) {
 			get: (_, event) => {
 				const name = mappings[event];
 
-				new Proxy(() => {}, {
+				return new Proxy(() => {}, {
 					apply: (_, __, [window]) => ({
 						listen: (arg) => window.listen(name, arg),
 						once: (arg) => window.once(name, arg),

--- a/examples/app/src/bindings.ts
+++ b/examples/app/src/bindings.ts
@@ -51,10 +51,33 @@ async typesafeErrorsUsingThiserrorWithValue() : Promise<Result<null, MyError2>> 
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+async myClassMethod1(東京: MyClass, someArg: string) : Promise<void> {
+    await TAURI_INVOKE("__MyClass__method1", { 東京, someArg });
 }
 }
 
 /** user-defined events **/
+
+export class MyClass {
+	inner: { id: number };
+
+	constructor(inner: { id: number }) {
+		this.inner = inner;
+	}
+
+	async method1(someArg: string) : Promise<void> {
+    const 東京 = this.inner;
+	await TAURI_INVOKE("__MyClass__method1", { 東京, someArg });
+}
+	async method2(someArg: string) : Promise<void> {
+    const 東京 = this.inner;
+	await TAURI_INVOKE("__MyClass__method2", { someArg });
+}
+}
+
+
+/** user-defined classes **/
 
 
 export const events = __makeEvents__<{

--- a/examples/app/src/main.ts
+++ b/examples/app/src/main.ts
@@ -1,5 +1,5 @@
 import { getCurrentWebview } from "@tauri-apps/api/webview";
-import { commands, events } from "./bindings";
+import { commands, events, MyClass } from "./bindings";
 // import { commands, events } from "./bindings-jsdoc.js";
 
 const appWindow = getCurrentWebview();
@@ -31,3 +31,6 @@ window.addEventListener("DOMContentLoaded", () => {
 
 events.emptyEvent.listen((e) => console.log(e));
 events.emptyEvent(appWindow).listen((e) => console.log(e));
+
+const a = new MyClass({ id: 42 });
+a.method1("someArg").then(() => console.log("DONE!"));

--- a/examples/custom-plugin/plugin/bindings.ts
+++ b/examples/custom-plugin/plugin/bindings.ts
@@ -46,7 +46,7 @@ type __EventObj__<T> = {
 	once: (
 		cb: TAURI_API_EVENT.EventCallback<T>,
 	) => ReturnType<typeof TAURI_API_EVENT.once<T>>;
-	emit: T extends null
+	emit: null extends T
 		? (payload?: T) => ReturnType<typeof TAURI_API_EVENT.emit>
 		: (payload: T) => ReturnType<typeof TAURI_API_EVENT.emit>;
 };

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -4,12 +4,14 @@
     html_favicon_url = "https://github.com/oscartbeaumont/specta/raw/main/.github/logo-128.png"
 )]
 
+use std::str::FromStr;
+
 use heck::ToKebabCase;
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote, ToTokens};
 use syn::{
-    parse_macro_input, parse_quote, ConstParam, DeriveInput, GenericParam, Generics, LifetimeParam,
-    TypeParam, WhereClause,
+    parse_macro_input, parse_quote, ConstParam, DeriveInput, FnArg, GenericParam, Generics,
+    ImplItem, Item, LifetimeParam, Pat, ReturnType, Token, TypeParam, Visibility, WhereClause,
 };
 
 #[proc_macro_derive(Event, attributes(tauri_specta))]
@@ -94,5 +96,255 @@ fn add_type_to_where_clause(generics: &Generics) -> Option<WhereClause> {
             let bounds = w.predicates.iter();
             Some(parse_quote! { where #(#bounds),* })
         }
+    }
+}
+
+#[proc_macro_attribute]
+pub fn class(
+    _attr: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let crate_ref = quote!(tauri_specta);
+    let item = syn::parse_macro_input!(input as syn::ItemImpl);
+
+    // TODO: Proper syn error
+    assert_eq!(
+        item.generics.params.len(),
+        0,
+        "generics not supported with #[specta::class]"
+    );
+
+    let ident = &item.self_ty;
+    let ident_str = ident.to_token_stream().to_string();
+
+    let methods = item.items.iter().filter_map(|item| match item {
+        ImplItem::Fn(function) => {
+            let crate_ref = quote!(specta);
+            let fn_ident = &function.sig.ident;
+
+            // TODO
+            // assert!(
+            //     function.sig.unsafety != Token![unsafe],
+            //     "unsafe functions are not supported with #[specta::class]"
+            // );
+            // assert!(
+            //     function.sig.abi.is_some(),
+            //     "ABI declarations are not supported with #[specta::class]"
+            // );
+            assert!(
+                function.sig.generics.params.is_empty(),
+                "generics not supported with #[specta::class]"
+            );
+            assert!(
+                function.sig.generics.where_clause.is_none(),
+                "where clauses not supported with #[specta::class]"
+            );
+
+            if function
+                .sig
+                .inputs
+                .iter()
+                .find(|i| match i {
+                    FnArg::Receiver(receiver) => receiver.reference.is_some(),
+                    FnArg::Typed(_) => false,
+                })
+                .is_some()
+            {
+                todo!("`&self` and `&mut self` are not supported with #[specta::class]")
+            }
+
+            let visibility = &function.vis;
+            let maybe_macro_export = match &visibility {
+                Visibility::Public(_) => {
+                    quote!(#[macro_export])
+                }
+                _ => Default::default(),
+            };
+
+            let function_name = &function.sig.ident;
+            let function_name_str = unraw(&function_name.to_string()).to_string();
+            let function_asyncness = match function.sig.asyncness {
+                Some(_) => true,
+                None => false,
+            };
+
+            let mut arg_names = Vec::new();
+            for input in function.sig.inputs.iter() {
+                let arg = match input {
+                    FnArg::Receiver(_) => quote!(東京),
+                    FnArg::Typed(arg) => match &*arg.pat {
+                        Pat::Ident(ident) => ident.ident.to_token_stream(),
+                        Pat::Macro(m) => m.mac.tokens.to_token_stream(),
+                        Pat::Struct(s) => s.path.to_token_stream(),
+                        Pat::Slice(s) => s.attrs[0].to_token_stream(),
+                        Pat::Tuple(s) => s.elems[0].to_token_stream(),
+                        _ => {
+                            // return Err(syn::Error::new_spanned(
+                            //     input,
+                            //     "functions with `#[specta]` must take named arguments",
+                            // ))
+                            todo!("functions with `#[specta]` must take named arguments");
+                        }
+                    },
+                };
+
+                let mut s = arg.to_string();
+
+                let s = if s.starts_with("r#") {
+                    s.split_off(2)
+                } else {
+                    s
+                };
+
+                arg_names.push(TokenStream::from_str(&s).unwrap());
+            }
+
+            let arg_signatures = function.sig.inputs.iter().map(|_| quote!(_));
+
+            // TODO: Support attributes
+            // let mut attrs = parse_attrs(&function.attrs)?;
+            // let common = crate::r#type::attr::CommonAttr::from_attrs(&mut attrs)?;
+
+            // let deprecated = common.deprecated_as_tokens(&crate_ref);
+            // let docs = common.doc;
+            let deprecated = quote!(None);
+            let docs = "";
+
+            let no_return_type = match function.sig.output {
+                syn::ReturnType::Default => true,
+                syn::ReturnType::Type(_, _) => false,
+            };
+
+            let wrapper_ident = format_ident!(
+                "__{}__{}",
+                ident.into_token_stream().to_string(),
+                &function.sig.ident
+            );
+
+            Some(quote! {
+                // TODO: Can this all just be `fn_datatype` on the wrapper function?
+                // specta::function::fn_datatype!(#wrapper_ident)(types)
+
+                // TODO: This is the same as the inside of `specta::specta`
+                // TODO: This is not really intended to be semver-stable
+                #crate_ref::internal::get_fn_datatype(
+                    // #ident::#fn_ident as fn(#(#arg_signatures),*) -> _, // TODO: Causing `self`
+                    #wrapper_ident as fn(#(#arg_signatures),*) -> _,
+                    #function_asyncness,
+                    #function_name_str.into(),
+                    types,
+                    &[#(stringify!(#arg_names).into()),* ],
+                    std::borrow::Cow::Borrowed(#docs),
+                    #deprecated,
+                    #no_return_type,
+                )
+            })
+        }
+        _ => None,
+    });
+
+    // TODO: I wonder we could PR something like this to Tauri or would that be too much???
+    let tauri_command_wrappers = item.items.iter().filter_map(|item| match item {
+        ImplItem::Fn(function) => {
+            let attrs = &function.attrs;
+            let vis = &function.vis;
+            let asyncness = &function.sig.asyncness;
+            let wait = &function
+                .sig
+                .asyncness
+                .as_ref()
+                .map(|_| quote!(.await))
+                .unwrap_or_default();
+            let original_ident = &function.sig.ident;
+            let wrapper_ident = format_ident!(
+                "__{}__{}",
+                ident.into_token_stream().to_string(),
+                &function.sig.ident
+            );
+
+            let (args_def, args): (Vec<_>, Vec<_>) = function
+                .sig
+                .inputs
+                .iter()
+                .map(|v| {
+                    let arg = match v {
+                        FnArg::Receiver(_) => quote!(東京),
+                        FnArg::Typed(arg) => match &*arg.pat {
+                            Pat::Ident(ident) => ident.ident.to_token_stream(),
+                            Pat::Macro(m) => m.mac.tokens.to_token_stream(),
+                            Pat::Struct(s) => s.path.to_token_stream(),
+                            Pat::Slice(s) => s.attrs[0].to_token_stream(),
+                            Pat::Tuple(s) => s.elems[0].to_token_stream(),
+                            _ => {
+                                // return Err(syn::Error::new_spanned(
+                                //     input,
+                                //     "functions with `#[specta]` must take named arguments",
+                                // ))
+                                todo!("functions with `#[specta]` must take named arguments");
+                            }
+                        },
+                    };
+
+                    let mut s = arg.to_string();
+
+                    let s = if s.starts_with("r#") {
+                        s.split_off(2)
+                    } else {
+                        s
+                    };
+
+                    let arg_ident = TokenStream::from_str(&s).unwrap();
+
+                    (
+                        match v {
+                            FnArg::Receiver(_) => quote!(#arg_ident: #ident),
+                            FnArg::Typed(ty) => {
+                                let ty = &ty.ty;
+                                quote!(#arg_ident: #ty)
+                            }
+                        },
+                        quote!(#arg_ident),
+                    )
+                })
+                .unzip();
+            let ret_type = &function.sig.output;
+
+            Some(quote! {
+                #[tauri::command]
+                #[specta::specta]
+                #(#attrs)*
+                #vis #asyncness fn #wrapper_ident(#(#args_def),*) #ret_type {
+                    #ident::#original_ident(#(#args),*) #wait
+                }
+            })
+        }
+        _ => None,
+    });
+
+    quote! {
+        #item
+
+        impl #crate_ref::Class for #ident {
+            fn collect(types: &mut specta::TypeCollection) -> #crate_ref::ClassDefinition {
+                <Self as specta::Type>::inline(types, specta::Generics::Definition);
+
+                #crate_ref::ClassDefinition {
+                    ident: #ident_str,
+                    ndt: types.remove(<Self as specta::NamedType>::sid()).expect("we register the type above!"),
+                    methods: vec![#(#methods),*],
+                }
+            }
+        }
+
+        #(#tauri_command_wrappers)*
+    }
+    .into()
+}
+
+fn unraw(s: &str) -> &str {
+    if s.starts_with("r#") {
+        s.split_at(2).1
+    } else {
+        s.as_ref()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,8 +192,8 @@ use std::{
 };
 
 use specta::{
-    datatype::{self, DataType},
-    Language, SpectaID, TypeMap,
+    datatype::{self, DataType, Function, NamedDataType},
+    Language, SpectaID, TypeCollection, TypeMap,
 };
 
 use tauri::{ipc::Invoke, Runtime};
@@ -204,6 +204,11 @@ use tauri::{ipc::Invoke, Runtime};
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 pub use tauri_specta_macros::Event;
+
+/// TODO
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+pub use tauri_specta_macros::class;
 
 mod builder;
 mod event;
@@ -254,8 +259,9 @@ pub struct ExportContext {
     pub commands: Vec<datatype::Function>,
     pub error_handling: ErrorHandlingMode,
     pub events: BTreeMap<&'static str, DataType>,
-    pub type_map: TypeMap,
+    pub types: TypeMap,
     pub constants: HashMap<Cow<'static, str>, serde_json::Value>,
+    pub classes: Vec<ClassDefinition>,
 }
 
 /// Implemented for all languages which Tauri Specta supports exporting to.
@@ -344,4 +350,16 @@ pub mod internal {
             panic!("Another event with name {} is already registered!", E::NAME)
         }
     }
+}
+
+pub trait Class {
+    fn collect(types: &mut TypeCollection) -> ClassDefinition;
+}
+
+#[derive(Debug, Clone)]
+// #[non_exhaustive] // TODO
+pub struct ClassDefinition {
+    pub ident: &'static str,
+    pub ndt: NamedDataType,
+    pub methods: Vec<Function>,
 }


### PR DESCRIPTION
## This is probally never going to land. It has some major issues!

 - Returning classes from commands (we need to adjust the serialization somehow). We need to account for `T` and `Vec<T>`, `MyStruct { a: T }` which makes this really hard.
 - What if the class is nested? That wouldn't know and hence would break.

 - Automatically register Tauri wrapper commands???




 - Ignore warnings about incorrect naming

 - Support references
 - static methods working
 - Typesafe error handling working
 - Move more of the internals into Specta
 - JSDoc exporter support
 - Support exporting doc comments properly

 - Support for Rust-only objects (store into Tauri state as an object pool w/ unique identifier that TS uses)

- Remove `東京` and use a proper identifier that isn't santised out.