### PR TITLE
sort constants by name so they dont change order

### DIFF
--- a/src/lang/js_ts.rs
+++ b/src/lang/js_ts.rs
@@ -25,9 +25,10 @@ pub fn render_all_parts<L: LanguageExt>(
     events: String,
     as_const: bool,
 ) -> Result<String, L::Error> {
-    let constants = cfg
-        .constants
-        .iter()
+    let mut constants = cfg.constants.iter().collect::<Vec<_>>();
+    constants.sort_by(|(a, _), (b, _)| a.cmp(b));
+    let constants = constants
+        .into_iter()
         .map(|(name, value)| {
             let mut as_constt = None;
             if as_const {


### PR DESCRIPTION
we use tauri specta and its most great but one thing that was really annoying was that the order of the constants changed all the time which resulted in a git change for no real reason. all this does it move them to an array then sort first. this means thats the same constants will always produce the same result. 