### PR TITLE
fix: replace HashMap with BTreeMap for constants to ensure alphabetical order

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::Cow,
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet},
     fs::{self, File},
     io::Write,
     path::Path,
@@ -89,7 +89,7 @@ pub struct Builder<R: Runtime = tauri::Wry> {
     events: BTreeMap<&'static str, DataType>,
     event_sids: BTreeSet<SpectaID>,
     types: TypeMap,
-    constants: HashMap<Cow<'static, str>, serde_json::Value>,
+    constants: BTreeMap<Cow<'static, str>, serde_json::Value>,
 }
 
 impl<R: Runtime> Default for Builder<R> {
@@ -102,7 +102,7 @@ impl<R: Runtime> Default for Builder<R> {
             events: Default::default(),
             event_sids: Default::default(),
             types: TypeMap::default(),
-            constants: HashMap::default(),
+            constants: BTreeMap::default(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,16 +184,11 @@
 )]
 
 use core::fmt;
-use std::{
-    borrow::Cow,
-    collections::{BTreeMap, HashMap},
-    path::Path,
-    sync::Arc,
-};
+use std::{borrow::Cow, collections::BTreeMap, path::Path, sync::Arc};
 
 use specta::{
     datatype::{self, DataType},
-    Language, SpectaID, TypeMap,
+    SpectaID, TypeMap,
 };
 
 use tauri::{ipc::Invoke, Runtime};
@@ -255,7 +250,7 @@ pub struct ExportContext {
     pub error_handling: ErrorHandlingMode,
     pub events: BTreeMap<&'static str, DataType>,
     pub type_map: TypeMap,
-    pub constants: HashMap<Cow<'static, str>, serde_json::Value>,
+    pub constants: BTreeMap<Cow<'static, str>, serde_json::Value>,
 }
 
 /// Implemented for all languages which Tauri Specta supports exporting to.


### PR DESCRIPTION
Hey guys! Love tauri specta, but had a small issue with the constants order in the typescript bindings changing constantly on every rebuild.

It happens because you're using a `HashMap` which by design is non deterministic, meaning even though you were already sorting them alphabetically in the code, they still were stored, and by consequence printed to `bindings.ts` in a random order.

I switched to a `BTreeMap`, which instead preserves alphabetical ordering. Ideally, we'd add a test for this too, but it wouldn't make that much sense for now imo.

I'm using this in production, so it'd be great if you could release this soon (it's a minuscule change anyway).