### PR TITLE
Fix to accept either `Window` or `Webview` types

### DIFF
--- a/examples/app/src/bindings-jsdoc.js
+++ b/examples/app/src/bindings-jsdoc.js
@@ -130,7 +130,8 @@ import {
 } from "@tauri-apps/api/core";
 import * as TAURI_API_EVENT from "@tauri-apps/api/event";
 
-/** @typedef {typeof import("@tauri-apps/api/window").WebviewWindowHandle} __WebviewWindowHandle__ */
+/** @typedef {typeof import("@tauri-apps/api/webview").Webview} __Webview__ */
+/** @typedef {typeof import("@tauri-apps/api/window").Window} __Window__ */
 
 /**
  * @template T
@@ -157,7 +158,7 @@ import * as TAURI_API_EVENT from "@tauri-apps/api/event";
  * @param {Record<keyof T, string>} mappings
  * @returns {{
  * 	 [K in keyof T]: __EventObj__<T[K]> & {
- *	   (handle: __WebviewWindowHandle__): __EventObj__<T[K]>;
+ *	   (handle: __Webview__ | __Window__): __EventObj__<T[K]>;
  *   };
  * }}
  */

--- a/examples/app/src/bindings.ts
+++ b/examples/app/src/bindings.ts
@@ -85,7 +85,8 @@ import {
 	Channel as TAURI_CHANNEL,
 } from "@tauri-apps/api/core";
 import * as TAURI_API_EVENT from "@tauri-apps/api/event";
-import { type WebviewWindow as __WebviewWindow__ } from "@tauri-apps/api/webviewWindow";
+import { type Webview as __Webview__ } from "@tauri-apps/api/webview";
+import { type Window as __Window__ } from "@tauri-apps/api/window";
 
 type __EventObj__<T> = {
 	listen: (
@@ -109,7 +110,7 @@ function __makeEvents__<T extends Record<string, any>>(
 	return new Proxy(
 		{} as unknown as {
 			[K in keyof T]: __EventObj__<T[K]> & {
-				(handle: __WebviewWindow__): __EventObj__<T[K]>;
+				(handle: __Webview__ | __Window__): __EventObj__<T[K]>;
 			};
 		},
 		{
@@ -117,7 +118,7 @@ function __makeEvents__<T extends Record<string, any>>(
 				const name = mappings[event as keyof T];
 
 				return new Proxy((() => {}) as any, {
-					apply: (_, __, [window]: [__WebviewWindow__]) => ({
+					apply: (_, __, [window]: [__Webview__ | __Window__]) => ({
 						listen: (arg: any) => window.listen(name, arg),
 						once: (arg: any) => window.once(name, arg),
 						emit: (arg: any) => window.emit(name, arg),

--- a/examples/custom-plugin/plugin/bindings.ts
+++ b/examples/custom-plugin/plugin/bindings.ts
@@ -37,7 +37,8 @@ import {
 	Channel as TAURI_CHANNEL,
 } from "@tauri-apps/api/core";
 import * as TAURI_API_EVENT from "@tauri-apps/api/event";
-import { type WebviewWindow as __WebviewWindow__ } from "@tauri-apps/api/webviewWindow";
+import { type Webview as __Webview__ } from "@tauri-apps/api/webview";
+import { type Window as __Window__ } from "@tauri-apps/api/window";
 
 type __EventObj__<T> = {
 	listen: (
@@ -61,7 +62,7 @@ function __makeEvents__<T extends Record<string, any>>(
 	return new Proxy(
 		{} as unknown as {
 			[K in keyof T]: __EventObj__<T[K]> & {
-				(handle: __WebviewWindow__): __EventObj__<T[K]>;
+				(handle: __Webview__ | __Window__): __EventObj__<T[K]>;
 			};
 		},
 		{
@@ -69,7 +70,7 @@ function __makeEvents__<T extends Record<string, any>>(
 				const name = mappings[event as keyof T];
 
 				return new Proxy((() => {}) as any, {
-					apply: (_, __, [window]: [__WebviewWindow__]) => ({
+					apply: (_, __, [window]: [__Webview__ | __Window__]) => ({
 						listen: (arg: any) => window.listen(name, arg),
 						once: (arg: any) => window.once(name, arg),
 						emit: (arg: any) => window.emit(name, arg),

--- a/src/lang/globals.js
+++ b/src/lang/globals.js
@@ -4,7 +4,8 @@ import {
 } from "@tauri-apps/api/core";
 import * as TAURI_API_EVENT from "@tauri-apps/api/event";
 
-/** @typedef {typeof import("@tauri-apps/api/window").WebviewWindowHandle} __WebviewWindowHandle__ */
+/** @typedef {typeof import("@tauri-apps/api/webview").Webview} __Webview__ */
+/** @typedef {typeof import("@tauri-apps/api/window").Window} __Window__ */
 
 /**
  * @template T
@@ -31,7 +32,7 @@ import * as TAURI_API_EVENT from "@tauri-apps/api/event";
  * @param {Record<keyof T, string>} mappings
  * @returns {{
  * 	 [K in keyof T]: __EventObj__<T[K]> & {
- *	   (handle: __WebviewWindowHandle__): __EventObj__<T[K]>;
+ *	   (handle: __Webview__ | __Window__): __EventObj__<T[K]>;
  *   };
  * }}
  */

--- a/src/lang/globals.ts
+++ b/src/lang/globals.ts
@@ -3,7 +3,8 @@ import {
 	Channel as TAURI_CHANNEL,
 } from "@tauri-apps/api/core";
 import * as TAURI_API_EVENT from "@tauri-apps/api/event";
-import { type WebviewWindow as __WebviewWindow__ } from "@tauri-apps/api/webviewWindow";
+import { type Webview as __Webview__ } from "@tauri-apps/api/webview";
+import { type Window as __Window__ } from "@tauri-apps/api/window";
 
 type __EventObj__<T> = {
 	listen: (
@@ -27,7 +28,7 @@ function __makeEvents__<T extends Record<string, any>>(
 	return new Proxy(
 		{} as unknown as {
 			[K in keyof T]: __EventObj__<T[K]> & {
-				(handle: __WebviewWindow__): __EventObj__<T[K]>;
+				(handle: __Webview__ | __Window__): __EventObj__<T[K]>;
 			};
 		},
 		{
@@ -35,7 +36,7 @@ function __makeEvents__<T extends Record<string, any>>(
 				const name = mappings[event as keyof T];
 
 				return new Proxy((() => {}) as any, {
-					apply: (_, __, [window]: [__WebviewWindow__]) => ({
+					apply: (_, __, [window]: [__Webview__ | __Window__]) => ({
 						listen: (arg: any) => window.listen(name, arg),
 						once: (arg: any) => window.once(name, arg),
 						emit: (arg: any) => window.emit(name, arg),


### PR DESCRIPTION
Currently, TypeScript only accepts the `WebviewWindow` (`Webview`) type, but I want it to accept `Window` as well. Since `Window` has `listen`, `once`, and `emit` implemented, there will be no problems with behavior.

This change also enables the use of handlers acquired with `getCurrentWindow`.

```ts
import { getCurrentWindow } from "@tauri-apps/api/webview";
import { events } from "./bindings.ts";

const appWindow = getCurrentWindow();

events.emptyEvent(appWindow).listen((e) => console.log(e));
```