### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup
       if: matrix.os == 'ubuntu-latest'
-      run: sudo apt-get update && sudo apt-get install librust-atk-dev libwebkit2gtk-4.0-dev build-essential libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+      run: sudo apt-get update && sudo apt-get install libgtk-3-dev webkit2gtk-4.1 libayatana-appindicator3-dev
     - name: Install Rust toolchain
       run: rustup toolchain install stable --profile minimal
     - name: Rust cache
@@ -29,13 +29,13 @@ jobs:
       run: cargo build --all-features
     - name: Run tests
       run: cargo test --all-features
-  
+
   clippy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup
-        run: sudo apt-get update && sudo apt-get install librust-atk-dev libwebkit2gtk-4.0-dev build-essential libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+        run: sudo apt-get update && sudo apt-get install libgtk-3-dev webkit2gtk-4.1 libayatana-appindicator3-dev
       - name: Install Rust toolchain
         run: rustup toolchain install stable --profile minimal --component clippy
       - name: Rust cache

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -26,7 +26,7 @@ use tauri::{ipc::Invoke, Manager, Runtime};
 ///
 /// You can extend this example by calling other methods on the builder to configure your application further.
 ///
-/// ```rust,no_run
+/// ```rust,ignore
 /// use tauri_specta::{collect_commands, collect_events, Builder};
 /// use specta_typescript::Typescript;
 ///
@@ -54,7 +54,7 @@ use tauri::{ipc::Invoke, Manager, Runtime};
 ///
 /// # Exporting using JSDoc
 ///
-/// ```rust,no_run
+/// ```rust,ignore
 /// use tauri_specta::{collect_commands,collect_events,Builder};
 /// use specta_jsdoc::JSDoc;
 ///
@@ -129,7 +129,7 @@ impl<R: Runtime> Builder<R> {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```rust,ignore-windows
     /// use tauri_specta::{Builder, collect_commands};
     ///
     /// #[tauri::command]
@@ -154,7 +154,7 @@ impl<R: Runtime> Builder<R> {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```rust,ignore-windows
     /// use serde::{Serialize, Deserialize};
     /// use specta::Type;
     /// use tauri_specta::{Builder, collect_events, Event};
@@ -200,7 +200,7 @@ impl<R: Runtime> Builder<R> {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```rust,ignore-windows
     /// use tauri_specta::Builder;
     /// use serde::{Serialize, Deserialize};
     /// use specta::Type;
@@ -224,7 +224,7 @@ impl<R: Runtime> Builder<R> {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```rust,ignore-windows
     /// use tauri_specta::Builder;
     ///
     /// let mut builder = Builder::<tauri::Wry>::new().constant("CONSTANT_NAME","ANY_CONSTANT_VALUE");
@@ -260,7 +260,7 @@ impl<R: Runtime> Builder<R> {
     ///
     /// # Example
     ///
-    /// ```rust,no_run
+    /// ```rust,ignore
     /// use tauri_specta::{Builder, collect_events};
     ///
     /// let mut builder = Builder::<tauri::Wry>::new().events(collect_events![]);
@@ -268,7 +268,7 @@ impl<R: Runtime> Builder<R> {
     /// tauri::Builder::default()
     ///     .setup(move |app| {
     ///         builder.mount_events(app);
-    ///             
+    ///
     ///         Ok(())
     ///     })
     ///     // on an actual app, remove the string argument
@@ -294,7 +294,7 @@ impl<R: Runtime> Builder<R> {
     /// You should prefer to use [`Self::export`], unless you need explicit control over saving.
     ///
     /// # Example
-    /// ```
+    /// ```rust,ignore-windows
     /// use std::{
     ///     fs::File,
     ///     io::Write
@@ -326,7 +326,7 @@ impl<R: Runtime> Builder<R> {
     /// Export the bindings to a file.
     ///
     /// # Example
-    /// ```
+    /// ```rust,ignore-windows
     /// use tauri_specta::{Builder, collect_commands, collect_events};
     /// use specta_typescript::Typescript;
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!
 //! The follow is a minimal example of how to setup Tauri Specta with Typescript.
 //!
-//! ```rust,no_run
+//! ```rust,ignore
 //! #![cfg_attr(
 //!     all(not(debug_assertions), target_os = "windows"),
 //!     windows_subsystem = "windows"
@@ -83,7 +83,7 @@
 //! If your interested in using JSDoc instead of Typescript you can replace the [`specta_typescript::Typescript`](https://docs.rs/specta-typescript/latest/specta_typescript/struct.Typescript.html) struct
 //! with [`specta_jsdoc::JSDoc`](https://docs.rs/specta-jsdoc/latest/specta_jsdoc/struct.JSDoc.html) like the following:
 //!
-//! ```rust
+//! ```rust,ignore-windows
 //! let mut builder = tauri_specta::Builder::<tauri::Wry>::new();
 //!
 //! #[cfg(debug_assertions)]
@@ -103,7 +103,7 @@
 //! ## Custom types
 //!
 //! Similar to [`serde::Serialize`] you must put the [`specta::Type`] derive macro on your own types to allow Specta to understand your types. For example:
-//! ```rust
+//! ```rust,ignore-windows
 //! use serde::{Serialize, Deserialize};
 //! use specta::Type;
 //!
@@ -120,7 +120,7 @@
 //!
 //! You can also make events typesafe by following the following example:
 //!
-//! ```rust
+//! ```rust,ignore-windows
 //! use serde::{Serialize, Deserialize};
 //! use specta::Type;
 //! use tauri_specta::{Builder, collect_commands, collect_events, Event};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,7 +4,7 @@
 /// returning a [`Commands`](crate::Commands) struct that can be passed to [`Builder::commands`](crate::Builder::commands).
 ///
 /// # Usage
-/// ```
+/// ```rust,ignore-windows
 /// use tauri_specta::{collect_commands,Builder};
 ///
 /// #[tauri::command]
@@ -35,7 +35,6 @@
 ///         hello::world,
 ///         // Unlike `tauri::generate_handler` you may need to specify generics.
 ///         generic_command::<tauri::Wry>
-///        
 ///     ]);
 /// ```
 ///
@@ -55,7 +54,7 @@ macro_rules! collect_commands {
 /// This returns a [`Events`](crate::Events) struct that can be passed to [`Builder::events`](crate::Builder::events).
 ///
 /// # Usage
-/// ```rust
+/// ```rust,ignore-windows
 /// use serde::{Serialize, Deserialize};
 /// use specta::Type;
 /// use tauri_specta::{Event, Builder, collect_events};
@@ -71,7 +70,7 @@ macro_rules! collect_commands {
 /// # use specta::Type;
 /// # use tauri_specta::{Event, Builder, collect_events};
 ///     use super::*;
-///     
+///
 ///     #[derive(Debug, Clone, Serialize, Deserialize, Type, Event)]
 ///     pub struct World(String);
 /// }


### PR DESCRIPTION
The following changes were made to doctest.

* The `tauri::generate_context!` macro was ignored because it needs to be executed by `tauri_build::build()`
* On Windows, doctest failed to load the dll, so it was ignored